### PR TITLE
Add Control Script for Nyquist Filters in IQ Mode

### DIFF
--- a/scripts/a.sh
+++ b/scripts/a.sh
@@ -96,6 +96,7 @@ case "$MODE_OUTPUT" in
 	FREQUENCY_OUT=0
 	OUTPUT=videots
 	MODE=IQ
+	$PATHSCRIPT"/ctlfilter.sh"
 	#GAIN=0
 	;;
 	QPSKRF)

--- a/scripts/ctlfilter.sh
+++ b/scripts/ctlfilter.sh
@@ -1,0 +1,91 @@
+########## ctlfilter.sh ############
+
+# Called by a.sh in IQ mode to switch in correct
+# Nyquist Filter
+
+############ Set Environment Variables ###############
+
+
+PATHSCRIPT=/home/pi/rpidatv/scripts
+CONFIGFILE=$PATHSCRIPT"/rpidatvconfig.txt"
+
+############### PIN DEFINITION ###########
+
+#filter_bit0 LSB of filter control word=GPIO 16 / Header 36  
+filter_bit0=16
+
+#filter_bit1 Mid Bit of filter control word=GPIO 26 / Header 37
+filter_bit1=26
+
+#filter_bit0 MSB of filter control word=GPIO 20 / Header 38
+filter_bit2=20
+
+gpio -g mode $filter_bit0 out
+gpio -g mode $filter_bit1 out
+gpio -g mode $filter_bit2 out
+
+############### Function to read Config File ###############
+
+get_config_var() {
+lua - "$1" "$2" <<EOF
+local key=assert(arg[1])
+local fn=assert(arg[2])
+local file=assert(io.open(fn))
+for line in file:lines() do
+local val = line:match("^#?%s*"..key.."=(.*)$")
+if (val ~= nil) then
+print(val)
+break
+end
+end
+EOF
+}
+
+############### Read Symbol Rate #########################
+
+SYMBOLRATEK=$(get_config_var symbolrate $CONFIGFILE)
+
+############### Switch GPIOs based on Symbol Rate ########
+
+case "$SYMBOLRATEK" in
+	125)
+                gpio -g write $filter_bit0 0;
+                gpio -g write $filter_bit1 0;
+		gpio -g write $filter_bit2 0;
+	;;
+	250)
+		gpio -g write $filter_bit0 1;
+                gpio -g write $filter_bit1 0;
+                gpio -g write $filter_bit2 0;
+	;;
+	333)
+                gpio -g write $filter_bit0 0;
+                gpio -g write $filter_bit1 1;
+                gpio -g write $filter_bit2 0;
+        ;;
+        500)
+                gpio -g write $filter_bit0 1;
+                gpio -g write $filter_bit1 1;
+                gpio -g write $filter_bit2 0;
+	;;
+        1000)
+                gpio -g write $filter_bit0 0;
+                gpio -g write $filter_bit1 0;
+                gpio -g write $filter_bit2 1;
+        ;;
+        2000)
+                gpio -g write $filter_bit0 1;
+                gpio -g write $filter_bit1 0;
+                gpio -g write $filter_bit2 1;
+        ;;
+	*)
+                gpio -g write $filter_bit0 1;
+                gpio -g write $filter_bit1 0;
+                gpio -g write $filter_bit2 1;
+	;;
+esac
+
+### End ###
+
+# Revert to a.sh #
+


### PR DESCRIPTION
A call has been added to a.sh in IQ mode to run ctlfilter.sh.  This script reads the current symbol rate from the config file and then sets (physical) pins 36, 37 and 38 based on the symbol rate.  Current version only supports exact symbol rates of 125, 250, 333 500, 1000 and 2000.  Future versions may select filters based on a range of symbol rates.  ctlfilter.sh is added to the scripts folder.