### PR TITLE
Update Makefile for Stretch

### DIFF
--- a/src/gui/Makefile
+++ b/src/gui/Makefile
@@ -1,5 +1,5 @@
 INCLUDEFLAGS=-I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vcos/pthreads -fPIC
-LIBFLAGS=-L/opt/vc/lib -lEGL -lGLESv2 -ljpeg
+LIBFLAGS=-L/opt/vc/lib -lbrcmEGL -lbrcmGLESv2 -ljpeg
 FONTLIB=/usr/share/fonts/truetype/ttf-dejavu
 FONTFILES=DejaVuSans.inc  DejaVuSansMono.inc DejaVuSerif.inc
 FFT_C = ./hello_fft/mailbox.c ./hello_fft/gpu_fft.c ./hello_fft/gpu_fft_base.c ./hello_fft/gpu_fft_twiddles.c ./hello_fft/gpu_fft_shaders.c
@@ -36,7 +36,7 @@ library: oglinit.o libshapes.o
 	gcc $(LIBFLAGS) -shared -o libshapes.so oglinit.o libshapes.o 
 
 INCLUDEFLAGS2=-lpthread -I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vcos/pthreads -I..
-LIBFLAGS2=-L/opt/vc/lib -lEGL -lGLESv2 -lbcm_host -lpthread  -ljpeg -lrt -lm -ldl -lfftw3f
+LIBFLAGS2=-L/opt/vc/lib -lbrcmEGL -lbrcmGLESv2 -lbcm_host -lpthread  -ljpeg -lrt -lm -ldl -lfftw3f
 
 rpidatvtouch: rpidatvtouch.c  
 	gcc -Wall $(INCLUDEFLAGS2) -o  rpidatvgui rpidatvtouch.c  libshapes.o oglinit.o $(LIBFLAGS2) 


### PR DESCRIPTION
Debian Stretch on the raspberry pi has renamed the libraries -lEGL -lGLESv2 to -lbrcmEGL -lbrcmGLESv2

Without this change compilation will fail.